### PR TITLE
Removed OpenCL requirements from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 #XRT
-find_package(OpenCL REQUIRED)
 set(XRT_DIR "${CMAKE_SOURCE_DIR}/cmake")
 find_package(XRT REQUIRED)
 

--- a/src/FINNCppDriver/CMakeLists.txt
+++ b/src/FINNCppDriver/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(finnhpc FINNDriver.cpp)
 target_include_directories(finnhpc SYSTEM PRIVATE ${XRT_INCLUDE_DIRS})
 target_include_directories(finnhpc PRIVATE ${FINN_SRC_DIR})
 target_link_directories(finnhpc PRIVATE ${XRT_LIB_CORE_LOCATION} ${XRT_LIB_OCL_LOCATION})
-target_link_libraries(finnhpc PRIVATE finnc_core finnc_options Threads::Threads OpenCL xrt_coreutil uuid finn_config nlohmann_json::nlohmann_json OpenMP::OpenMP_CXX)
+target_link_libraries(finnhpc PRIVATE finnc_core finnc_options Threads::Threads xrt_coreutil uuid finn_config nlohmann_json::nlohmann_json OpenMP::OpenMP_CXX)
 set_target_properties(finnhpc
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"

--- a/src/FINNCppDriver/core/CMakeLists.txt
+++ b/src/FINNCppDriver/core/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(finnc_core SHARED ${CORE_SRC})
 target_include_directories(finnc_core SYSTEM PUBLIC ${XRT_INCLUDE_DIRS} ${FINN_SRC_DIR})
 target_link_directories(finnc_core PUBLIC ${XRT_LIB_CORE_LOCATION})
 target_link_directories(finnc_core PUBLIC ${XRT_LIB_OCL_LOCATION})
-target_link_libraries(finnc_core PUBLIC finnc_options finn_config Threads::Threads OpenCL xrt_coreutil rt uuid)
+target_link_libraries(finnc_core PUBLIC finnc_options finn_config Threads::Threads xrt_coreutil rt uuid)
 
 add_library(finnc_core_test SHARED ${CORE_SRC})
 target_include_directories(finnc_core_test SYSTEM PUBLIC ${XRT_MOCK_INCLUDE} ${FINN_SRC_DIR})
@@ -14,7 +14,7 @@ target_compile_definitions(finnc_core_test PRIVATE UNITTEST=1)
 # target_include_directories(finnc_core_test SYSTEM PUBLIC ${XRT_INCLUDE_DIRS})
 # target_link_directories(finnc_core_test PUBLIC ${XRT_LIB_CORE_LOCATION})
 # target_link_directories(finnc_core_test PUBLIC ${XRT_LIB_OCL_LOCATION})
-# target_link_libraries(finnc_core_test PUBLIC ${Boost_LIBRARIES} finnc_options finnc_utils Threads::Threads OpenCL xrt_coreutil uuid)
+# target_link_libraries(finnc_core_test PUBLIC ${Boost_LIBRARIES} finnc_options finnc_utils Threads::Threads xrt_coreutil uuid)
 
 set_target_properties(finnc_core
     PROPERTIES


### PR DESCRIPTION
OpenCL does not seem to be explicitly needed as a dependency when compiling/linking with XRT and can thus, if tests run successfully, be removed from the cmake configuration.